### PR TITLE
Add IgnoresAccessChecksTo trick

### DIFF
--- a/MonkArena/Utils.cs
+++ b/MonkArena/Utils.cs
@@ -3,6 +3,24 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Security;
+using System.Runtime.CompilerServices;
+using System.Security.Permissions;
+
+[assembly: IgnoresAccessChecksTo("Assembly-CSharp")]
+[assembly: SecurityPermission(SecurityAction.RequestMinimum, SkipVerification = true)]
+[module: UnverifiableCode]
+
+namespace System.Runtime.CompilerServices {
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+    public class IgnoresAccessChecksToAttribute : Attribute {
+        public IgnoresAccessChecksToAttribute(string assemblyName) {
+            AssemblyName = assemblyName;
+        }
+ 
+        public string AssemblyName { get; }
+    }
+}
 
 namespace MonkArena {
     public static class Utils {


### PR DESCRIPTION
i got bored of playing minecraft so i did this instead.

This should mean that the mod can be compiled with a PublicityStunt-ed assembly but will work when you run the game without it. I think. If you actually use this then make sure it works and don't just trust this since it's a bizarre internal thing and might do something unexpected.